### PR TITLE
fix: IMDSv2 support in route53 script and surface SSM failure output

### DIFF
--- a/.github/scripts/update-route53.sh
+++ b/.github/scripts/update-route53.sh
@@ -5,7 +5,16 @@ REGION=af-south-1
 HOSTED_ZONE_ID="${HOSTED_ZONE_ID}"
 RECORD_NAME=api.rwars.steven-webber.com.
 
-IP=$(curl -sf http://169.254.169.254/latest/meta-data/public-ipv4)
+# Prefer IMDSv2 (token required); fall back to IMDSv1 if tokens are disabled.
+TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 300" || true)
+if [ -n "$TOKEN" ]; then
+  IP=$(curl -sf -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/public-ipv4 || true)
+else
+  IP=$(curl -sf http://169.254.169.254/latest/meta-data/public-ipv4 || true)
+fi
+
 if [ -z "$IP" ]; then
   echo "Could not determine public IP from instance metadata" >&2
   exit 1

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -155,10 +155,19 @@ jobs:
           --query "Command.CommandId" \
           --output text)
 
+        # Don't let the waiter's non-zero exit abort before we print the
+        # instance-side output, which tells us why the command failed.
         aws ssm wait command-executed \
           --command-id "$COMMAND_ID" \
           --instance-id "$INSTANCE_ID" \
-          --region "$AWS_REGION"
+          --region "$AWS_REGION" || true
+
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --region "$AWS_REGION" \
+          --query "Status" \
+          --output text)
 
         aws ssm get-command-invocation \
           --command-id "$COMMAND_ID" \
@@ -166,6 +175,11 @@ jobs:
           --region "$AWS_REGION" \
           --query "[StandardOutputContent, StandardErrorContent]" \
           --output text
+
+        if [ "$STATUS" != "Success" ]; then
+          echo "SSM command finished with status: $STATUS" >&2
+          exit 1
+        fi
 
     - name: Deploy to EC2 via SSM
       env:
@@ -224,7 +238,14 @@ jobs:
         aws ssm wait command-executed \
           --command-id "$COMMAND_ID" \
           --instance-id "$INSTANCE_ID" \
-          --region "$AWS_REGION"
+          --region "$AWS_REGION" || true
+
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --region "$AWS_REGION" \
+          --query "Status" \
+          --output text)
 
         aws ssm get-command-invocation \
           --command-id "$COMMAND_ID" \
@@ -232,6 +253,11 @@ jobs:
           --region "$AWS_REGION" \
           --query "[StandardOutputContent, StandardErrorContent]" \
           --output text
+
+        if [ "$STATUS" != "Success" ]; then
+          echo "SSM command finished with status: $STATUS" >&2
+          exit 1
+        fi
 
     - name: Update Route 53 A record for API endpoint
       env:


### PR DESCRIPTION
The on-boot route53 update script fetched the public IP via an IMDSv1 GET, which fails on instances that enforce IMDSv2. Request an IMDSv2 token first and fall back to v1 only when tokens are disabled.

Also restructure the install and health-check SSM steps so the waiter's non-zero exit no longer aborts the step before the instance-side StandardOutput/StandardError is printed, then fail explicitly when the command status is not Success. This makes the real on-instance error visible instead of a bare "Waiter ... Failed".